### PR TITLE
Problem: inconsitency of AGE arguments for actor and cleaner script

### DIFF
--- a/fty-metric-store-cleaner
+++ b/fty-metric-store-cleaner
@@ -4,7 +4,7 @@
 PATH=/usr/bin:/usr/sbin:/bin:/sbin
 export PATH
 
-export CONF_PREFIX=BIOS_METRIC_STORE_AGE_
+export CONF_PREFIX=FTY_METRIC_STORE_AGE_
 
 # read env variables
 test -f /etc/default/bios-db-rw || die "Can't get db credentials"
@@ -59,6 +59,24 @@ do_remove_hist() {
 if [[ -z "${DB_USER}" || -z "${DB_PASSWD}" ]]; then
     die "DB_USER or DB_PASSWD are empty"
 fi
+
+CFG=${1}
+if [[ -z "${CFG}" ]]; then
+    CFG=/etc/fty-metric-store/fty-metric-store.cfg
+fi
+
+if [[ ! -f "${CFG}" ]]; then
+    die "Config file not found"
+fi
+
+FTY_METRIC_STORE_AGE_RT=$(grep -E '^ +rt' "${CFG}" | cut -d '=' -f 2)
+FTY_METRIC_STORE_AGE_15m=$(grep -E '^ +15m' "${CFG}" | cut -d '=' -f 2)
+FTY_METRIC_STORE_AGE_30m=$(grep -E '^ +30m' "${CFG}" | cut -d '=' -f 2)
+FTY_METRIC_STORE_AGE_1h=$(grep -E '^ +1h' "${CFG}" | cut -d '=' -f 2)
+FTY_METRIC_STORE_AGE_8h=$(grep -E '^ +8h' "${CFG}" | cut -d '=' -f 2)
+FTY_METRIC_STORE_AGE_24h=$(grep -E '^ +24h' "${CFG}" | cut -d '=' -f 2)
+FTY_METRIC_STORE_AGE_7d=$(grep -E '^ +7d' "${CFG}" | cut -d '=' -f 2)
+FTY_METRIC_STORE_AGE_30d=$(grep -E '^ +30d' "${CFG}" | cut -d '=' -f 2)
 
 for AGE_NAME in $(set | grep "^${CONF_PREFIX}" | cut -d '=' -f 1); do
     AGE=${!AGE_NAME}

--- a/include/fty_metric_store.h
+++ b/include/fty_metric_store.h
@@ -26,5 +26,6 @@
 #include "fty_metric_store_library.h"
 
 //  Add your own public definitions here, if you need them
+#define FTY_METRIC_STORE_CONF_PREFIX "FTY_METRIC_STORE_AGE"
 
 #endif

--- a/src/actor_commands.cc
+++ b/src/actor_commands.cc
@@ -145,9 +145,9 @@ actor_commands (
         zstr_free (&config_file);
     }
     else
-    if (streq (cmd, "BIOS_METRIC_STORE_AGE"))
+    if (streq (cmd, FTY_METRIC_STORE_CONF_PREFIX))
     {
-        zsys_debug ("BIOS_METRIC_STORE_AGE is not yet implemented!");
+        zsys_debug ("%s is not yet implemented!", FTY_METRIC_STORE_CONF_PREFIX);
     }
     else {
         log_warning ("Command '%s' is unknown or not implemented", cmd);

--- a/src/fty-metric-store-cleaner.service.in
+++ b/src/fty-metric-store-cleaner.service.in
@@ -13,7 +13,7 @@ EnvironmentFile=-/usr/share/bios/etc/default/fty__fty-metric-store.service.conf
 EnvironmentFile=-/etc/default/bios
 EnvironmentFile=-/etc/default/fty__fty-metric-store.service.conf
 EnvironmentFile=-/etc/default/bios-db-rw
-ExecStart=@prefix@/bin/fty-metric-store-cleaner
+ExecStart=@prefix@/bin/fty-metric-store-cleaner @sysconfdir@/@PACKAGE@/fty-metric-store.cfg
 
 [Install]
 WantedBy=bios.target

--- a/src/fty-metric-store.cfg.in
+++ b/src/fty-metric-store.cfg.in
@@ -3,8 +3,8 @@
 server
     log_level = "LOG_WARNING"   #   ...tbd...
     verbose = 0                 #   Do verbose logging of activity?
-store
-    rt = 0          # ...tbd...
+store                           # define the storage time for various windows, 0 means do not save at all
+    rt = 0
     15m = 1
     30m = 1
     1h = 7

--- a/src/fty_metric_store.cc
+++ b/src/fty_metric_store.cc
@@ -32,7 +32,6 @@
 
 static const char *AGENT_NAME = "fty-metric-store";
 static const char *ENDPOINT = "ipc://@/malamute";
-static const char *CONF_PREFIX = "FTY_METRIC_STORE_AGE";
 #define STEPS_SIZE 8
 static const char *STEPS[STEPS_SIZE] = {"RT", "15m", "30m", "1h", "8h", "1d", "7d", "30d"};
 static const char *DEFAULTS[STEPS_SIZE] = {"0", "1", "1",   "7",  "7",  "30", "30", "180"};
@@ -147,14 +146,14 @@ int main (int argc, char *argv [])
     for (int i = 0; i != STEPS_SIZE; i++) {
         char *env;
         const char *dfl = DEFAULTS [i];
-        int r = asprintf (&env, "%s_%s", CONF_PREFIX, STEPS[i]);
+        int r = asprintf (&env, "%s_%s", FTY_METRIC_STORE_CONF_PREFIX, STEPS[i]);
         assert (r != -1);
 
         if (getenv (env)) {
             dfl = getenv (env);
         }
 
-        zstr_sendx (ms_server, CONF_PREFIX, STEPS [i], dfl, NULL);
+        zstr_sendx (ms_server, FTY_METRIC_STORE_CONF_PREFIX, STEPS [i], dfl, NULL);
 
         zstr_free (&env);
     }


### PR DESCRIPTION
Solution: use FTY_METRIC_STORE everywhere + add a support to read those
values in cleaner script

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>