### PR TITLE
Problem: it's hard to debug metric cleaner

### DIFF
--- a/fty-metric-store-cleaner
+++ b/fty-metric-store-cleaner
@@ -6,9 +6,7 @@ export PATH
 
 export CONF_PREFIX=FTY_METRIC_STORE_AGE_
 
-# read env variables
-test -f /etc/default/bios-db-rw || die "Can't get db credentials"
-. /etc/default/bios-db-rw
+DRY_RUN=false
 
 die() {
   echo "FATAL: $@" >&2
@@ -20,7 +18,10 @@ info() {
 }
 
 do_mysql() {
-  mysql -N -B -u "${DB_USER}" -p"${DB_PASSWD}" box_utf8 -e "$@"
+  info "mysql -N -B -u ${DB_USER} -p${DB_PASSWD} box_utf8 -e $@"
+  if ! ${DRY_RUN}; then
+      mysql -N -B -u "${DB_USER}" -p"${DB_PASSWD}" box_utf8 -e "$@"
+  fi
 }
 
 do_remove_RT() {
@@ -35,7 +36,6 @@ do_remove_RT() {
     age=$((age * 24*3600))
     #TODO: there is no clear distinction between RT and historical entries in t_bios_measurement/t_bios_measurement_topic
     #      reply on a fact that except things from computation modules nothing have underscore in a name
-    info "DELETE FROM t_bios_measurement WHERE topic_id IN (SELECT id FROM t_bios_measurement_topic WHERE topic NOT LIKE \"%_%\") AND timestamp < UNIX_TIMESTAMP(NOW())-${age}"
     do_mysql "DELETE FROM t_bios_measurement WHERE topic_id IN (SELECT id FROM t_bios_measurement_topic WHERE topic NOT LIKE \"%_%\") AND timestamp < UNIX_TIMESTAMP(NOW())-${age}"
 }
 
@@ -51,22 +51,34 @@ do_remove_hist() {
     info "Removing historical values, age=${age}, step=${step}"
     age=$((age * 24*3600))
 
-    info "DELETE FROM t_bios_measurement WHERE topic_id IN (SELECT id FROM t_bios_measurement_topic WHERE topic LIKE \"%${step}%\") AND timestamp < UNIX_TIMESTAMP(NOW())-${age}"
     do_mysql "DELETE FROM t_bios_measurement WHERE topic_id IN (SELECT id FROM t_bios_measurement_topic WHERE topic LIKE \"%${step}%\") AND timestamp < UNIX_TIMESTAMP(NOW())-${age}"
 }
 
 ### MAIN
-if [[ -z "${DB_USER}" || -z "${DB_PASSWD}" ]]; then
-    die "DB_USER or DB_PASSWD are empty"
-fi
 
 CFG=${1}
+
+if [[ "${CFG}" == "--dry-run" ]]; then
+    DRY_RUN=true
+    shift 1
+    CFG="${1}"
+fi
+
 if [[ -z "${CFG}" ]]; then
     CFG=/etc/fty-metric-store/fty-metric-store.cfg
 fi
 
 if [[ ! -f "${CFG}" ]]; then
     die "Config file not found"
+fi
+
+if ! ${DRY_RUN}; then
+    # read DB env variables
+    test -f /etc/default/bios-db-rw || die "Can't get db credentials"
+    . /etc/default/bios-db-rw
+    if [[ -z "${DB_USER}" || -z "${DB_PASSWD}" ]]; then
+        die "DB_USER or DB_PASSWD are empty"
+    fi
 fi
 
 FTY_METRIC_STORE_AGE_RT=$(grep -E '^ +rt' "${CFG}" | cut -d '=' -f 2)


### PR DESCRIPTION
Solution: add --dry-run mode, which prints SQL queries

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>

cc: @jana-rapava 