### PR TITLE
Problem: delete MIGHT be accidentally more greedy

### DIFF
--- a/fty-metric-store-cleaner
+++ b/fty-metric-store-cleaner
@@ -51,7 +51,7 @@ do_remove_hist() {
     info "Removing historical values, age=${age}, step=${step}"
     age=$((age * 24*3600))
 
-    do_mysql "DELETE FROM t_bios_measurement WHERE topic_id IN (SELECT id FROM t_bios_measurement_topic WHERE topic LIKE \"%${step}%\") AND timestamp < UNIX_TIMESTAMP(NOW())-${age}"
+    do_mysql "DELETE FROM t_bios_measurement WHERE topic_id IN (SELECT id FROM t_bios_measurement_topic WHERE topic LIKE \"%${step}@%\") AND timestamp < UNIX_TIMESTAMP(NOW())-${age}"
 }
 
 ### MAIN


### PR DESCRIPTION
Solution: remove only rows which %$step@% pattern, so entries with
max_temperature_15m@ups8h won't be deleted

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>