### PR TITLE
Problem : [BIOS-3340] adapt fty_metric_store_age parameters and fix 0 age support in fty-metric-store-cleaner

### DIFF
--- a/fty-metric-store-cleaner
+++ b/fty-metric-store-cleaner
@@ -42,7 +42,7 @@ do_mysql() {
 do_remove_RT() {
     local age=${1}
 
-    if [[ -z "${age}" || ${age} -lt 0 ]]; then
+    if [[ -z "${age}" || ${age} -le 0 ]]; then
         info "${CONF_PREFIX}RT is missing or non positive, not removing real time data"
         return 0
     fi
@@ -58,7 +58,7 @@ do_remove_hist() {
     local age=${1}
     local step=${2}
 
-    if [[ -z "${age}" || ${age} -le 0 ]]; then
+    if [[ -z "${age}" || ${age} -lt 0 ]]; then
         info "${CONF_PREFIX}${step} is missing or non positive, not removing historical data"
         return 0
     fi

--- a/fty-metric-store-cleaner
+++ b/fty-metric-store-cleaner
@@ -42,7 +42,7 @@ do_mysql() {
 do_remove_RT() {
     local age=${1}
 
-    if [[ -z "${age}" || ${age} -le 0 ]]; then
+    if [[ -z "${age}" || ${age} -lt 0 ]]; then
         info "${CONF_PREFIX}RT is missing or non positive, not removing real time data"
         return 0
     fi

--- a/src/fty-metric-store.cfg.in
+++ b/src/fty-metric-store.cfg.in
@@ -6,10 +6,10 @@ server
 store                           # define the storage time for various windows, 0 means do not save at all
     rt = 0
     15m = 1
-    30m = 1
+    30m = 0
     1h = 7
-    8h = 7
-    24h = 30
+    8h = 0
+    24h = 730
     7d = 180
     30d = 730
 malamute


### PR DESCRIPTION
Problem : [BIOS-3340] defines a new strategy (FTY_METRIC_STORE_AGE_xx) to delete deprecated data from t_bios_measurement table
Problem : if the age is 0, data are never cleaned

