### PR TITLE
Problem: systemd bin have wrong path on Debian

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -60,6 +60,12 @@ EXTRA_DIST += \
     src/multi_row.h \
     src/fty_metric_store_classes.h
 
+# Victims of "include" are EXTRA_DISTed by autotools, however neither "-include"
+# nor "sinclude" are covered by this magic.
+if ENABLE_DIST_SRC_MAKEMODULE_LOCAL
+EXTRA_DIST += src/Makemodule-local.am
+endif
+
 include $(srcdir)/src/Makemodule.am
 sinclude $(srcdir)/src/Makemodule-local.am # Optional project-local hook
 

--- a/configure.ac
+++ b/configure.ac
@@ -933,6 +933,11 @@ AM_COND_IF([WITH_SYSTEMD_UNITS],
     ])],
     [])
 
+AC_MSG_CHECKING([whether to redistribute src/Makemodule-local.am])
+AC_CHECK_FILE([$srcdir/src/Makemodule-local.am], [enable_dist_SRC_MAKEMODULE_LOCAL=yes], [enable_dist_SRC_MAKEMODULE_LOCAL=no])
+AM_CONDITIONAL([ENABLE_DIST_SRC_MAKEMODULE_LOCAL], [test "x$enable_dist_SRC_MAKEMODULE_LOCAL" = "xyes"])
+AC_MSG_RESULT([$enable_dist_SRC_MAKEMODULE_LOCAL])
+
 AC_OUTPUT
 
 # Print configure summary and list make options

--- a/packaging/debian/fty-metric-store.install
+++ b/packaging/debian/fty-metric-store.install
@@ -3,6 +3,6 @@ usr/share/man/man1/fty-metric-store.1
 usr/bin/fty-metric-store-cleaner
 etc/fty-metric-store/fty-metric-store.cfg
 lib/systemd/system/fty-metric-store.service
-/usr/lib/systemd/system/fty-metric-store-cleaner.service
-/usr/lib/systemd/system/fty-metric-store-cleaner.timer
+lib/systemd/system/fty-metric-store-cleaner.service
+lib/systemd/system/fty-metric-store-cleaner.timer
 


### PR DESCRIPTION
Solution: Regenerate with the latest zproject to fix and get more fixes

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>