### PR TITLE
Problem: service starts without DB credentials in env

### DIFF
--- a/src/fty-metric-store-cleaner.service.in
+++ b/src/fty-metric-store-cleaner.service.in
@@ -18,7 +18,7 @@ EnvironmentFile=-@sysconfdir@/default/fty
 EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
 EnvironmentFile=-@sysconfdir@/default/fty__fty-metric-store.service.conf
 Environment="prefix=@prefix@"
-EnvironmentFile=-@sysconfdir@/default/bios-db-rw
+EnvironmentFile=@sysconfdir@/default/bios-db-rw
 ExecStart=@prefix@/bin/fty-metric-store-cleaner @sysconfdir@/@PACKAGE@/fty-metric-store.cfg
 
 [Install]

--- a/src/fty-metric-store-cleaner.timer.in
+++ b/src/fty-metric-store-cleaner.timer.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=Timer to call fty-metric-store-cleaner.service
+Requires=fty-db-init.service
+After=fty-db-init.service
 PartOf=bios.target
 
 [Timer]

--- a/src/fty-metric-store.service.in
+++ b/src/fty-metric-store.service.in
@@ -16,7 +16,7 @@ EnvironmentFile=-@sysconfdir@/default/bios__%n.conf
 EnvironmentFile=-@sysconfdir@/default/fty
 EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
 Environment="prefix=@prefix@"
-EnvironmentFile=-@sysconfdir@/default/bios-db-rw
+EnvironmentFile=@sysconfdir@/default/bios-db-rw
 ExecStart=@prefix@/bin/fty-metric-store @sysconfdir@/@PACKAGE@/fty-metric-store.cfg
 Restart=always
 


### PR DESCRIPTION
Solution: Make DB credentials a required EnvironmentFile
Also: Make the timer Require same prerequisites as its service